### PR TITLE
Rebuild the image on Debian bookworm and check it in CI

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,28 @@
+name: Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/image.yml'
+      - 'Dockerfile'
+  pull_request:
+    paths:
+      - '.github/workflows/image.yml'
+      - 'Dockerfile'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Build image
+        run: docker build --tag langrisha/keybase .
+
+      - name: Check client
+        run: docker run --rm langrisha/keybase keybase status

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,32 @@
+# syntax=docker/dockerfile:1
 FROM buildpack-deps:bookworm-curl
 LABEL maintainer="Filip Dupanović (https://keybase.io/langrisha)"
 
-RUN \
-	# Install dependencies
-	apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		fuse \
-	# Get and verify Keybase.io's code signing key
-	&& curl https://keybase.io/docs/server_security/code_signing_key.asc | \
-		gpg --import \
-	&& gpg --fingerprint 222B85B0F90BE2D24CFEB93F47484E50656D16C7 \
-	# Get, verify and install client package
-	&& curl -O https://prerelease.keybase.io/keybase_amd64.deb.sig \
-	&& curl -O https://prerelease.keybase.io/keybase_amd64.deb \
-	&& gpg --verify keybase_amd64.deb.sig keybase_amd64.deb \
-	&& apt-get install -y --no-install-recommends ./keybase_amd64.deb \
-	# Create group, user
-	&& groupadd -g 1000 keybase \
-	&& useradd --create-home -g keybase -u 1000 keybase \
-	# Cleanup
-	&& rm -r /var/lib/apt/lists/* \
-	&& rm keybase_amd64.deb*
+RUN <<EOF
+set -eux
+
+# Install dependencies
+apt-get update
+apt-get install -y --no-install-recommends fuse
+
+# Get and verify Keybase.io's code signing key
+curl https://keybase.io/docs/server_security/code_signing_key.asc | gpg --import
+gpg --fingerprint 222B85B0F90BE2D24CFEB93F47484E50656D16C7
+
+# Get, verify and install client package
+curl -O https://prerelease.keybase.io/keybase_amd64.deb.sig
+curl -O https://prerelease.keybase.io/keybase_amd64.deb
+gpg --verify keybase_amd64.deb.sig keybase_amd64.deb
+apt-get install -y --no-install-recommends ./keybase_amd64.deb
+
+# Create group, user
+groupadd -g 1000 keybase
+useradd --create-home -g keybase -u 1000 keybase
+
+# Cleanup
+rm -r /var/lib/apt/lists/*
+rm keybase_amd64.deb*
+EOF
 
 USER keybase
 WORKDIR /home/keybase

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,23 @@
-FROM buildpack-deps:jessie-curl
-LABEL maintainer "Filip Dupanović (https://keybase.io/langrisha)"
+FROM buildpack-deps:bookworm-curl
+LABEL maintainer="Filip Dupanović (https://keybase.io/langrisha)"
 
 RUN \
 	# Install dependencies
-	apt-get update && apt-get install -y \
+	apt-get update \
+	&& apt-get install -y --no-install-recommends \
 		fuse \
-		libappindicator1 \
-		--no-install-recommends \
-
 	# Get and verify Keybase.io's code signing key
 	&& curl https://keybase.io/docs/server_security/code_signing_key.asc | \
 		gpg --import \
 	&& gpg --fingerprint 222B85B0F90BE2D24CFEB93F47484E50656D16C7 \
-
 	# Get, verify and install client package
 	&& curl -O https://prerelease.keybase.io/keybase_amd64.deb.sig \
 	&& curl -O https://prerelease.keybase.io/keybase_amd64.deb \
 	&& gpg --verify keybase_amd64.deb.sig keybase_amd64.deb \
-	&& dpkg -i keybase_amd64.deb \
-	&& apt-get install -f \
-
+	&& apt-get install -y --no-install-recommends ./keybase_amd64.deb \
 	# Create group, user
 	&& groupadd -g 1000 keybase \
 	&& useradd --create-home -g keybase -u 1000 keybase \
-
 	# Cleanup
 	&& rm -r /var/lib/apt/lists/* \
 	&& rm keybase_amd64.deb*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-keybase
 
-[![Workspace][workspace-badge]][workspace]
+[![Image][image-badge]][image] [![Workspace][workspace-badge]][workspace]
 
 Docker container with signed Keybase.io client install.
 
@@ -73,6 +73,10 @@ moved to the archive, so the image could no longer be built at all.
 
 Initial release
 
+[image]:
+  https://github.com/langri-sha/docker-keybase/actions/workflows/image.yml
+[image-badge]:
+  https://github.com/langri-sha/docker-keybase/actions/workflows/image.yml/badge.svg
 [workspace]:
   https://github.com/langri-sha/docker-keybase/actions/workflows/workspace.yml
 [workspace-badge]:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ user when the container starts.
 
 ## Changelog
 
+### Unreleased
+
+Rebuilt on Debian bookworm. Debian jessie went end-of-life and its apt suites
+moved to the archive, so the image could no longer be built at all.
+
 ### [1.0.0] - 2016-03-25
 
 Initial release


### PR DESCRIPTION
`docker build .` has been failing outright: `buildpack-deps:jessie-curl` is
Debian 8, whose suites moved to `archive.debian.org` years ago, so `apt-get
update` 404s before anything else runs.

Moves the base to `buildpack-deps:bookworm-curl`. `libappindicator1` is gone
from current Debian, so rather than name the client's dependencies by hand the
verified `.deb` is now installed through apt and apt resolves them — it pulls
`libayatana-appindicator3-1` today. That also removes the `dpkg -i` /
`apt-get install -f` repair dance. The signing-key verification is untouched.

With the build working again, the `Image` workflow restores what Travis used to
do and #8 could not carry over: build the image, then run `keybase status`
against it.

Verified locally — clean build with no Dockerfile warnings, `keybase status`
exits 0 on Keybase 6.6.3, and the container still runs as `keybase` (uid/gid
1000) in `/home/keybase` with `bash` as the default command.

Closes #7